### PR TITLE
Instrument new create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -7,4 +7,8 @@ class InstrumentsController < ApplicationController
   def show
     @instrument = Instrument.find(params[:id])
   end
+
+  def new
+    @instrument = Instrument.new
+  end
 end

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -1,4 +1,7 @@
 class InstrumentsController < ApplicationController
+  # On ne s'authentifie pas pour voir la liste des instruments
+  # mais on doit être authentifié pour toute autre action concernant les instruments
+  skip_before_action :authenticate_user!, only: :index
 
   def index
     @instruments = Instrument.all
@@ -10,5 +13,22 @@ class InstrumentsController < ApplicationController
 
   def new
     @instrument = Instrument.new
+  end
+
+  def create
+    @instrument = Instrument.new(instrument_params)
+    @instrument.user = current_user
+
+    if @instrument.save
+      redirect_to @instrument, notice: 'Instrument was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def instrument_params
+    params.require(:instrument).permit(:name, :description, :size, :instrument_type, :status, :price_per_day, photos: [])
   end
 end

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -22,6 +22,7 @@ class InstrumentsController < ApplicationController
     if @instrument.save
       redirect_to @instrument, notice: 'Instrument was successfully created.'
     else
+      flash.now[:alert] = 'There was an error while creating the instrument.'
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
+  # On ne s'authentifie pas pour la page d'accueil
+  skip_before_action :authenticate_user!, only: :home
+
   def home
   end
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,5 +1,7 @@
 class Instrument < ApplicationRecord
+  # For instrument types and sizes, we use a predefined list to avoid input errors. Add more types to make it exhaustive. This constant is called in create and update actions.
   INSTRUMENT_TYPES = %w[String Woodwind Brass Percussion Electronic].freeze
+  INSTRUMENT_SIZES = %w[Standard Large Compact Mini XL].freeze
 
   belongs_to :user
 
@@ -17,10 +19,10 @@ class Instrument < ApplicationRecord
   # Validations
   # An instrument must have a name, description, size, instrument type, status, and price per day.
 
-  # For instrument types, we use a predefined list to avoid input errors. Add more types to make it exhaustive.
+
   validates :instrument_type, presence: true, inclusion: { in: INSTRUMENT_TYPES }
   validates :price_per_day, presence: true, numericality: { greater_than: 0 }
-  validates :size, presence: true, inclusion: { in: %w[Standard Large Compact Mini XL] }
+  validates :size, presence: true, inclusion: { in: INSTRUMENT_SIZES }
   validates :description, presence: true, length: { minimum: 10, maximum: 400 }
   validates :name, presence: true, length: { minimum: 2, maximum: 100 }
   validates :status, presence: true, inclusion: { in: %w[available booked maintenance] }

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,4 +1,6 @@
 class Instrument < ApplicationRecord
+  INSTRUMENT_TYPES = %w[String Woodwind Brass Percussion Electronic].freeze
+
   belongs_to :user
 
   # An instrument can be booked many times and the bookings will persist if the instrument is deleted for historical records.
@@ -16,7 +18,7 @@ class Instrument < ApplicationRecord
   # An instrument must have a name, description, size, instrument type, status, and price per day.
 
   # For instrument types, we use a predefined list to avoid input errors. Add more types to make it exhaustive.
-  validates :instrument_type, presence: true, inclusion: { in: %w[String Woodwind Brass Percussion Electronic] }
+  validates :instrument_type, presence: true, inclusion: { in: INSTRUMENT_TYPES }
   validates :price_per_day, presence: true, numericality: { greater_than: 0 }
   validates :size, presence: true, inclusion: { in: %w[Standard Large Compact Mini XL] }
   validates :description, presence: true, length: { minimum: 10, maximum: 400 }

--- a/app/views/instruments/new.html.erb
+++ b/app/views/instruments/new.html.erb
@@ -4,9 +4,9 @@
     <%= f.input :name %>
     <%= f.input :description %>
     <%= f.input :instrument_type, collection: Instrument::INSTRUMENT_TYPES, prompt: "Select instrument type" %>
-    <%= f.input :price_per_day %>
-    <%= f.input :size %>
-    <%= f.input :status %>
-    <%= f.button :submit %>
+    <%= f.input :price_per_day, label: "Price/day (€)" %>
+    <%= f.input :size, collection: %w[Standard Large Compact Mini XL], prompt: "Select size" %>
+    <%= f.input :status, collection: %w[available booked maintenance], prompt: "Select status" %>
+    <%= f.button :submit, "Make it available", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/instruments/new.html.erb
+++ b/app/views/instruments/new.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <h1>What instrument will you make available?</h1>
+  <%= simple_form_for @instrument do |f| %>
+    <%= f.input :name %>
+    <%= f.input :description %>
+    <%= f.input :instrument_type, collection: Instrument::INSTRUMENT_TYPES, prompt: "Select instrument type" %>
+    <%= f.input :price_per_day %>
+    <%= f.input :size %>
+    <%= f.input :status %>
+    <%= f.button :submit %>
+  <% end %>
+</div>

--- a/app/views/instruments/new.html.erb
+++ b/app/views/instruments/new.html.erb
@@ -3,10 +3,11 @@
   <%= simple_form_for @instrument do |f| %>
     <%= f.input :name %>
     <%= f.input :description %>
+    <%= f.input :photos, as: :file, input_html: { multiple: true } %>
     <%= f.input :instrument_type, collection: Instrument::INSTRUMENT_TYPES, prompt: "Select instrument type" %>
     <%= f.input :price_per_day, label: "Price/day (€)" %>
-    <%= f.input :size, collection: %w[Standard Large Compact Mini XL], prompt: "Select size" %>
-    <%= f.input :status, collection: %w[available booked maintenance], prompt: "Select status" %>
+    <%= f.input :size, collection: Instrument::INSTRUMENT_SIZES, prompt: "Select size" %>
+    <%= f.input :status, collection: %w[Available Booked Maintenance], prompt: "Select status" %>
     <%= f.button :submit, "Make it available", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
 <h1>Stringbnb</h1>
 <p>Rent instruments nearby!</p>
 <%= link_to "See all instruments", instruments_path %>
+<%= link_to "Rent your instrument!", new_instrument_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "pages#home"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :instruments, only: [:index, :show]
+  resources :instruments, only: [:index, :show, :new, :create]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_25_105951) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_25_181432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookings", force: :cascade do |t|
     t.date "starting_date"
@@ -67,6 +95,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_25_105951) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bookings", "instruments"
   add_foreign_key "bookings", "users"
   add_foreign_key "instruments", "users"


### PR DESCRIPTION
- ajout des routes new et create pour les instruments
- ajout du formulaire de création des instruments
- modification du modèle instrument pour stocker les tailles et les types dans des constantes facilement modifiables et surtout pouvant être appellées dans les formulaires pour les dropdowns
- les pages home et index sont publiques mais désormais pour voir les détails d'un instrument ou pour en mettre un à la location il faudra s'authentifier
![Capture d’écran 2025-06-25 212056](https://github.com/user-attachments/assets/4ead0400-d225-4d45-8997-331e7c956ec4)
