### PR TITLE
fix instrument liting and rubocop -A

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "jbuilder"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -62,7 +62,7 @@ gem 'binding_of_caller', '~> 1.0'
 group :development, :test do
   gem "dotenv-rails"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ]
+  gem "debug", platforms: %i[mri windows]
 end
 
 group :development do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name address phone_number])
 
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :address, :phone_number])
-
-    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :address, :phone_number])
-
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name address phone_number])
   end
 end

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -33,6 +33,7 @@ class BookingsController < ApplicationController
       redirect_to dashboard_path, alert: "Vous ne pouvez que supprimez les reservations qui vous appartienne."
     end
   end
+
   private
 
   def set_instrument

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -9,6 +9,9 @@ class InstrumentsController < ApplicationController
 
   def show
     @instrument = Instrument.find(params[:id])
+    if user_signed_in?
+    @booking = Booking.find_by(user: current_user, instrument: @instrument)
+    end
   end
 
   def new

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,6 +1,7 @@
 class Instrument < ApplicationRecord
   # For instrument types and sizes, we use a predefined list to avoid input errors. Add more types to make it exhaustive. This constant is called in create and update actions.
-  INSTRUMENT_TYPES = instrument_types = %w[ Guitare Violon Piano Clarinette Batterie Flûte\ traversière Saxophone Contrebasse Trompette Harp Guitare\ électrique Accordéon Ukulélé Xylophone Harmonica].freeze
+  INSTRUMENT_TYPES = %w[Guitare Violon Piano Clarinette Batterie Flûte\ traversière Saxophone
+                        Contrebasse Trompette Harp Guitare\ électrique Accordéon Ukulélé Xylophone Harmonica].freeze
   INSTRUMENT_SIZES = %w[Standard Large Compact Mini XL].freeze
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,5 +22,6 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true, length: { minimum: 2, maximum: 50 }
   validates :address, presence: true, length: { minimum: 10, maximum: 200 }
-  validates :phone_number, presence: true, length: { minimum: 10, maximum: 15 }, format: { with: /\A\+?\d{10,15}\z/, message: "must be a valid phone number" }
+  validates :phone_number, presence: true, length: { minimum: 10, maximum: 15 },
+                           format: { with: /\A\+?\d{10,15}\z/, message: "must be a valid phone number" }
 end

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -21,8 +21,8 @@
       <div class="text-center mt-3">
         <%= link_to "Back to Instruments", instruments_path %>
     </div>
-    <% if user_signed_in? && current_user == booking.instrument.user %>
-      <%= link_to "Cancel booking", booking_path(booking), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" %>
+    <% if user_signed_in? && @booking.present? && current_user == @booking.user %>
+      <%= link_to "Cancel booking", booking_path(@booking), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm" %>
     <% end %>
     <% if user_signed_in? && current_user == @instrument.user %>
       <%= link_to "Edit this instrument", edit_instrument_path(@instrument), class: "btn btn-warning" %>


### PR DESCRIPTION
Correction d’une erreur de code (oubli d’un end)

Affichage de la réservation liée à l’utilisateur courant sur la page d’un instrument

Rendu du code plus clair et plus facile à maintenir